### PR TITLE
Update version of command-line-args and use command-line-usage for node6

### DIFF
--- a/bin/css-slam
+++ b/bin/css-slam
@@ -13,9 +13,10 @@
 const fs = require('fs');
 const path = require('path');
 const cliArgs = require('command-line-args');
+const getCliUsage = require('command-line-usage');
 const slam = require('../');
 
-const cli = cliArgs([
+const options = [
   {
     name: 'source',
     alias: 's',
@@ -37,16 +38,22 @@ const cli = cliArgs([
     type: Boolean,
     description: 'Print this message'
   }
-]);
+];
+
+const args = cliArgs(options);
 
 function getUsage() {
-  return cli.getUsage({
-    title: 'css-slam',
-    description: 'Minimal CSS, fast'
-  });
+  return getCliUsage([
+    {
+      header: 'css-slam',
+      content: 'Minimal CSS, fast'
+    },
+    {
+      header: 'Options',
+      optionList: options
+    }
+  ]);
 }
-
-const args = cli.parse();
 
 if (args.help) {
   console.log(getUsage());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-slam",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "Minimal CSS, fast",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-slam",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Minimal CSS, fast",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,8 @@
   "author": "The Polymer Authors",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "command-line-args": "^2.0.2",
+    "command-line-args": "^3.0.1",
+    "command-line-usage": "^3.0.5",
     "dom5": "^1.3.1",
     "shady-css-parser": "0.0.8"
   },


### PR DESCRIPTION
the new version of command-line-args requires command-line-usage to generate usage info.
